### PR TITLE
Move required imports into routes and remove deprecated ones in assets

### DIFF
--- a/assets.py
+++ b/assets.py
@@ -1,12 +1,9 @@
 import os
-from .forms import SearchForm, DeleteForm, AddRecord
-from flask import Flask, render_template, request, flash
+from flask import Flask
 from flask_sqlalchemy import SQLAlchemy
 from flask_bootstrap import Bootstrap
 
 app = Flask(__name__)
-
-from .assets import app
 
 # Flask-WTF requires an enryption key - the string can be anything
 app.config['SECRET_KEY'] = os.getenv('SECRET_KEY')

--- a/routes.py
+++ b/routes.py
@@ -1,4 +1,7 @@
-from .assets import app
+from flask import request, render_template, flash
+
+from .assets import app, Asset
+from .forms import *
 
 @app.route('/')
 def index():


### PR DESCRIPTION
From the looks of it, you were missing a number of imports in `routes.py`. To use the goodies from Flask like `request`, `render _template`, you need to import them in the file/module where you use them.

In `assets.py` the reasoning for why we import routes at the end of the file is that we need `app` and the `Asset` model. By moving the import all the way to the bottom of that file, we can let Python build up `app` and `Asset` first, before getting the items in `routes.py` to import them. I would try and find a better way to do this; this is ugly as heck cause it implicitly assumes Python is handling these calls in the order it is written. Obviously this is not always the case.

Finally I removed some deprecated imports in `assets.py` where you're no longer using things like `request`, `render_template` in the module.

In my local setup, it worked. I hope this PR works for you too!

All the best in your endeavours! What you've built is pretty cool so far and I look forward to hearing how this goes! Let's keep in touch =)